### PR TITLE
Switch to trusted publishing

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -16,6 +16,8 @@ jobs:
   build:
     name: ${{ matrix.platform.name }} ${{ matrix.dotnet.name }}
     runs-on: ${{ matrix.platform.os }}
+    permissions:
+      id-token: write
 
     strategy:
       fail-fast: false
@@ -59,9 +61,16 @@ jobs:
         name: "ClockifyClient (${{ matrix.platform.name }} ${{ matrix.dotnet.name }})"
         path: ${{ env.NuGetDirectory }}/*.*nupkg
 
+    - name: NuGet Login
+      if: github.ref == 'refs/heads/master' && matrix.dotnet.name == '.NET 9' && runner.os == 'Windows'
+      uses: NuGet/login@v1
+      id: login
+      with:
+        user: eXpl0it3r
+
     - name: Publish to NuGet
       if: github.ref == 'refs/heads/master' && matrix.dotnet.name == '.NET 9' && runner.os == 'Windows'
       run: |
         foreach($file in (Get-ChildItem ${{ env.NuGetDirectory }} -Recurse -Include *.nupkg)) {
-          dotnet nuget push $file --api-key "${{ secrets.NUGET_APIKEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
+          dotnet nuget push $file --api-key "${{steps.login.outputs.NUGET_API_KEY}}" --source https://api.nuget.org/v3/index.json --skip-duplicate
         }


### PR DESCRIPTION
Trusted Publishing is the way forward and is both "more secure", due to short-lived API tokens and doesn't require me to re-generate the API tokens every few months.